### PR TITLE
Add an .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=sqlite:data/dev.db

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ DELETE api/jobs/{job_id}
 
 ## Development
 A simple development database is used for testing migrations and using sqlxs compile time query 
-verification in `data/dev.db`. This is configured in the committed `.env` file. It's schema 
-should always be up-to-date.
+verification in `data/dev.db`. This is configured in the committed `.env` file. If you do not have an `.env` yet, you can
+copy the `.env.example` as starter.
+It's schema should always be up-to-date.
 
 To add a migration run (making sure you have the [sqlx-cli](https://lib.rs/crates/sqlx-cli))
 ```sh


### PR DESCRIPTION
I had issues running the `sqlx migrate run` without having a `DATABASE_URL` defined - as I did not have an `.env.` setup.
Just added an `.env.example` one can copy or move as `.env`.